### PR TITLE
Add options to target the pod network

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,3 +143,6 @@ Below is the complete list of available options that can be used to customize yo
 - **OVPN_K8S_DNS**: Kuberentes cluster dns server (required).
 - **OVPN_K8S_DH**: Openvpn dh.pem file path (default: /etc/openvpn/pki/dh.pem).
 - **OVPN_K8S_CERTS**: Openvpn certs.p12 file path (default: /etc/openvpn/pki/certs.p12).
+- **MORE_OPTS**: Misc Openvpn options, one per line, for example `duplicate-cn`
+- **OVPN_K8S_POD_NETWORK**: Kubernetes pod network (optional).
+- **OVPN_K8S_POD_SUBNET**: Kubernetes pod network subnet (optional).

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,6 +6,7 @@ fi
 
 set -e
 
+MORE_OPTS="${MORE_OPTS:-}"
 OVPN_NETWORK="${OVPN_NETWORK:-10.140.0.0}"
 OVPN_SUBNET="${OVPN_SUBNET:-255.255.0.0}"
 OVPN_PROTO="${OVPN_PROTO:-udp}"
@@ -32,6 +33,12 @@ if [ -z "${OVPN_K8S_DNS}" ]; then
     exit 1
 fi
 
+if [ ! -z "${OVPN_K8S_POD_NETWORK}" -a  ! -z "${OVPN_K8S_POD_SUBNET}" ]; then
+    POD_CONF="push \"route ${OVPN_K8S_POD_NETWORK} ${OVPN_K8S_POD_SUBNET}\""
+else
+    POD_CONF=""
+fi
+
 sed 's|{{OVPN_NETWORK}}|'"${OVPN_NETWORK}"'|' -i "${OVPN_CONFIG}"
 sed 's|{{OVPN_SUBNET}}|'"${OVPN_SUBNET}"'|' -i "${OVPN_CONFIG}"
 sed 's|{{OVPN_PROTO}}|'"${OVPN_PROTO}"'|' -i "${OVPN_CONFIG}"
@@ -42,11 +49,20 @@ sed 's|{{OVPN_K8S_SERVICE_SUBNET}}|'"${OVPN_K8S_SERVICE_SUBNET}"'|' -i "${OVPN_C
 sed 's|{{OVPN_K8S_DOMAIN}}|'"${OVPN_K8S_DOMAIN}"'|' -i "${OVPN_CONFIG}"
 sed 's|{{OVPN_K8S_DNS}}|'"${OVPN_K8S_DNS}"'|' -i "${OVPN_CONFIG}"
 
+sed 's|{{POD_CONF}}|'"${POD_CONF}"'|' -i "${OVPN_CONFIG}"
+sed 's|{{MORE_OPTS}}|'"${MORE_OPTS}"'|' -i "${OVPN_CONFIG}"
+
 iptables -t nat -A POSTROUTING -s ${OVPN_NETWORK}/${OVPN_SUBNET} -o ${OVPN_NATDEVICE} -j MASQUERADE
 
 mkdir -p /dev/net
 if [ ! -c /dev/net/tun ]; then
     mknod /dev/net/tun c 10 200
+fi
+
+if [ "$DEBUG" == "1" ]; then
+    echo ========== ${OVPN_CONFIG} ==========
+    cat "${OVPN_CONFIG}"
+    echo ====================================
 fi
 
 exec openvpn --config ${OVPN_CONFIG}

--- a/openvpn.conf
+++ b/openvpn.conf
@@ -17,6 +17,9 @@ status /tmp/openvpn-status.log
 user nobody
 group nogroup
 
+{{MORE_OPTS}}
+
 push "route {{OVPN_K8S_SERVICE_NETWORK}} {{OVPN_K8S_SERVICE_SUBNET}}"
+{{POD_CONF}}
 push "dhcp-option DOMAIN {{OVPN_K8S_DOMAIN}}"
 push "dhcp-option DNS {{OVPN_K8S_DNS}}"


### PR DESCRIPTION
If OVPN_K8S_POD_NETWORK and OVPN_K8S_POD_SUBNET are defined
they are pushed as route too. This allows for targetting a single pod
in case an overlay like flannel is used.

MORE_OPTS allows for hooks like 'duplicate-cn'
